### PR TITLE
refactor/ffi: replace OPEN_MODE_* constants with FFI enum

### DIFF
--- a/safe_app/src/ffi/tests/nfs.rs
+++ b/safe_app/src/ffi/tests/nfs.rs
@@ -126,7 +126,7 @@ fn basics() {
 // 4. Open the file again, now in a combined append + read mode.
 // 5. Read the file contents; it should be the same as we have written it.
 // Check that the file's created and modified timestamps are correct.
-// 6. Append a string to a file contents (by using `OPEN_MODE_APPEND`, _not_
+// 6. Append a string to a file contents (by using `OpenMode::Append`, _not_
 // by rewriting the existing data with an appended string).
 // 7. Update the file in the directory.
 // 8. Fetch the updated file version again and ensure that it contains
@@ -150,7 +150,7 @@ fn open_file() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_APPEND,
+            OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -211,7 +211,7 @@ fn open_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ | OPEN_MODE_APPEND,
+            OpenMode::Read as u64 | OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -303,7 +303,7 @@ fn open_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ,
+            OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -357,7 +357,7 @@ fn fetch_file() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -409,7 +409,7 @@ fn fetch_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ | OPEN_MODE_APPEND,
+            OpenMode::Read as u64 | OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -454,7 +454,7 @@ fn fetch_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ | OPEN_MODE_APPEND,
+            OpenMode::Read as u64 | OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -502,7 +502,7 @@ fn delete_then_open_file() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -557,7 +557,7 @@ fn delete_then_open_file() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -607,7 +607,7 @@ fn delete_then_open_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ | OPEN_MODE_APPEND,
+            OpenMode::Read as u64 | OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -650,7 +650,7 @@ fn open_close_file() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -699,7 +699,7 @@ fn open_close_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ,
+            OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -726,7 +726,7 @@ fn open_close_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -753,7 +753,7 @@ fn open_close_file() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_APPEND,
+            OpenMode::Append as u64,
             ud,
             cb,
         )))
@@ -780,7 +780,7 @@ fn file_open_read_write() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -804,7 +804,7 @@ fn file_open_read_write() {
             &app,
             &container_info,
             &written_file.into_repr_c(),
-            OPEN_MODE_OVERWRITE | OPEN_MODE_APPEND | OPEN_MODE_READ,
+            OpenMode::Overwrite as u64 | OpenMode::Append as u64 | OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -852,7 +852,7 @@ fn file_open_read_write() {
             &app,
             &container_info,
             &written_file.into_repr_c(),
-            OPEN_MODE_OVERWRITE | OPEN_MODE_APPEND | OPEN_MODE_READ,
+            OpenMode::Overwrite as u64 | OpenMode::Append as u64 | OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -897,7 +897,7 @@ fn file_read_chunks() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -945,7 +945,7 @@ fn file_read_chunks() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ,
+            OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -1019,7 +1019,7 @@ fn file_write_chunks() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_OVERWRITE,
+            OpenMode::Overwrite as u64,
             ud,
             cb,
         )))
@@ -1059,7 +1059,7 @@ fn file_write_chunks() {
             &app,
             &container_info,
             &file.into_repr_c(),
-            OPEN_MODE_READ,
+            OpenMode::Read as u64,
             ud,
             cb,
         )))
@@ -1097,7 +1097,7 @@ fn file_write_chunks() {
             &app,
             &container_info,
             &ffi_file,
-            OPEN_MODE_APPEND,
+            OpenMode::Append as u64,
             ud,
             cb
         )))
@@ -1111,7 +1111,7 @@ fn file_write_chunks() {
             &app,
             &container_info,
             &written_file.into_repr_c(),
-            OPEN_MODE_READ,
+            OpenMode::Read as u64,
             ud,
             cb,
         )))

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -33,7 +33,7 @@ use safe_core::ipc::{
     self, AppExchangeInfo, AuthGranted, AuthReq, ContainersReq, IpcMsg, IpcReq, ShareMDataReq,
 };
 use safe_core::nfs::file_helper::{self, Version};
-use safe_core::nfs::{File, Mode};
+use safe_core::nfs::{File, WriterMode};
 use safe_core::utils::test_utils::setup_client_with_net_obs;
 #[cfg(feature = "mock-network")]
 use safe_core::ConnectionManager;
@@ -245,7 +245,7 @@ pub fn create_file<S: Into<String>>(
         file_helper::write(
             client.clone(),
             File::new(vec![], published),
-            Mode::Overwrite,
+            WriterMode::Overwrite,
             container_info.enc_key().cloned(),
         )
         .then(move |res| {
@@ -314,7 +314,7 @@ pub fn delete_file<S: Into<String>>(
 pub fn write_file(
     authenticator: &Authenticator,
     file: File,
-    mode: Mode,
+    mode: WriterMode,
     encryption_key: Option<shared_secretbox::Key>,
     content: Vec<u8>,
 ) -> Result<(), AuthError> {

--- a/safe_core/src/nfs/file_helper.rs
+++ b/safe_core/src/nfs/file_helper.rs
@@ -9,7 +9,7 @@
 use crate::client::{Client, MDataInfo};
 use crate::crypto::shared_secretbox;
 use crate::errors::CoreError;
-use crate::nfs::{File, Mode, NfsError, NfsFuture, Reader, Writer};
+use crate::nfs::{File, NfsError, NfsFuture, Reader, Writer, WriterMode};
 use crate::self_encryption_storage::SelfEncryptionStorage;
 use crate::utils::FutureExt;
 use futures::{Future, IntoFuture};
@@ -208,7 +208,7 @@ where
 pub fn write<C: Client>(
     client: C,
     file: File,
-    mode: Mode,
+    mode: WriterMode,
     encryption_key: Option<shared_secretbox::Key>,
 ) -> Box<NfsFuture<Writer<C>>> {
     trace!("Creating a writer for a file");

--- a/safe_core/src/nfs/mod.rs
+++ b/safe_core/src/nfs/mod.rs
@@ -22,7 +22,7 @@ pub use self::dir::create_dir;
 pub use self::errors::NfsError;
 pub use self::file::File;
 pub use self::reader::Reader;
-pub use self::writer::{Mode, Writer};
+pub use self::writer::{Writer, WriterMode};
 use futures::Future;
 
 /// Helper type for futures that can result in `NfsError`.

--- a/safe_core/src/nfs/writer.rs
+++ b/safe_core/src/nfs/writer.rs
@@ -19,7 +19,7 @@ use self_encryption::{DataMap, SequentialEncryptor};
 
 /// Mode of the writer.
 #[derive(Clone, Copy, Debug)]
-pub enum Mode {
+pub enum WriterMode {
     /// Will create new data.
     Overwrite,
     /// Will append content to the existing data.
@@ -41,14 +41,16 @@ impl<C: Client> Writer<C> {
         client: &C,
         storage: SelfEncryptionStorage<C>,
         file: File,
-        mode: Mode,
+        mode: WriterMode,
         encryption_key: Option<shared_secretbox::Key>,
     ) -> Box<NfsFuture<Writer<C>>> {
         let fut = match mode {
-            Mode::Append => data_map::get(client, file.data_address(), encryption_key.clone())
-                .map(Some)
-                .into_box(),
-            Mode::Overwrite => ok!(None),
+            WriterMode::Append => {
+                data_map::get(client, file.data_address(), encryption_key.clone())
+                    .map(Some)
+                    .into_box()
+            }
+            WriterMode::Overwrite => ok!(None),
         };
         let client = client.clone();
         fut.or_else(|err| -> Box<NfsFuture<Option<DataMap>>> {

--- a/tests/src/real_network.rs
+++ b/tests/src/real_network.rs
@@ -35,7 +35,7 @@ use safe_core::ipc::req::{
 };
 use safe_core::ipc::resp::{MDataEntry, MDataKey, MDataValue};
 use safe_core::ipc::{AuthGranted, Permission};
-use safe_core::nfs::{Mode, NfsError};
+use safe_core::nfs::{NfsError, WriterMode};
 use safe_core::MDataInfo;
 use safe_core::{utils, CoreError};
 use safe_nd::{AppPermissions, MDataAction, MDataPermissionSet};
@@ -179,7 +179,7 @@ fn write_data() {
                 unwrap!(write_file(
                     &*auth_h,
                     file,
-                    Mode::Overwrite,
+                    WriterMode::Overwrite,
                     videos_md.enc_key().cloned(),
                     vec![1; 10],
                 ));


### PR DESCRIPTION
<!--
Thanks for contributing to the project! We recommend you check out our "Guide to contributing" page if you haven't already: https://github.com/maidsafe/safe_client_libs/wiki/Guide-to-contributing

Write your comment below this line: -->

Fixes #967 

Note that this doesn't remove the bitwise operations as mentioned in the issue -- I think this isn't possible as the FFI function must take a `u64`, to support the user passing in multiple modes via the `|` operator. However, the enum still ended up being cleaner than separate constants.

When we refactor out the API to have Rust-native equivalents for all current FFI functions (and the FFI functions become merely wrappers around those), we can make a Rust-native equivalent to the enum which looks like:

```rust
pub struct OpenMode {
    pub overwrite: bool,
    pub append: bool,
    pub read: bool,
}
```

which implements the `ReprC` trait to provide conversions to and from the FFI enum.

We should take our time thinking about this since we will need a strategy for FFI enums going forward, i.e. in safe-nd. Alternatives to the strategy in this PR include using crates such as [bitflags](https://docs.rs/bitflags/1.1.0/bitflags/) or [enum-primitive](https://andersk.github.io/enum_primitive-rs/enum_primitive/) but they are probably not worth the extra dependency as there is not much boilerplate here. The downsides to the current strategy include many `as u64` conversions and the continued use of bitwise operations, but these will go away once we can convert to the Rust-native equivalent and use more idiomatic operations.