### PR TITLE
refactor/request: introduce read/write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,8 +2047,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 [[package]]
 name = "safe-nd"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b9ca69f41d96da8c972538673f07d104691cced39af4d3eab91c1333cb3513"
+source = "git+https://github.com/oetyng/safe-nd.git?branch=introduce_read_write#fce4443ac0356ed92dd45af6dbf82cafb88f3cbc"
 dependencies = [
  "bincode",
  "crdts",

--- a/safe_app/Cargo.toml
+++ b/safe_app/Cargo.toml
@@ -23,7 +23,7 @@ miscreant = { version = "~0.4.2", features = ["soft-aes"] }
 rand = "~0.6"
 safe_authenticator = { path = "../safe_authenticator", version = "~0.16.3", optional = true }
 safe_core = { path = "../safe_core", version = "~0.41.3" }
-safe-nd = "0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 self_encryption = "~0.17.0"
 serde = "1.0.27"
 serde_derive = "1.0.27"
@@ -42,7 +42,7 @@ safe_core = { path = "../safe_core", version = "~0.41.3", features = ["testing"]
 ffi_utils = "~0.16.0"
 jni = "~0.12.0"
 safe_bindgen = { version = "~0.13.2", optional = true }
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 threshold_crypto = "~0.3.2"
 unwrap = "1.2.0"
 

--- a/safe_app/src/tests/mod.rs
+++ b/safe_app/src/tests/mod.rs
@@ -110,8 +110,8 @@ pub async fn login_registered_with_low_balance() -> Result<(), AppError> {
     // Register a hook prohibiting mutations and login
     let cm_hook = move |mut cm: ConnectionManager| -> ConnectionManager {
         cm.set_request_hook(move |req| {
-            if req.get_type() == RequestType::Mutation {
-                Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+            if req.get_type() == RequestType::Write {
+                Some(Response::Write(Err(SndError::InsufficientBalance)))
             } else {
                 // Pass-through
                 None

--- a/safe_authenticator/Cargo.toml
+++ b/safe_authenticator/Cargo.toml
@@ -21,7 +21,7 @@ log = "~0.4.1"
 lru-cache = "~0.1.1"
 rand = "~0.6"
 safe_core = { path = "../safe_core", version = "~0.41.3" }
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 serde = { version = "1.0.97", features = ["derive"] }
 threshold_crypto = "~0.3.2"
 tiny-keccak = "1.5.0"

--- a/safe_authenticator/src/client.rs
+++ b/safe_authenticator/src/client.rs
@@ -150,7 +150,7 @@ impl AuthClient {
         .await?;
 
         match response {
-            Response::Mutation(res) => res?,
+            Response::Write(res) => res?,
             _ => return Err(AuthError::from("Unexpected response")),
         };
 
@@ -391,7 +391,7 @@ impl AuthClient {
         ))?;
 
         let _resp = match resp {
-            Response::Mutation(res) => res.map_err(CoreError::from),
+            Response::Write(res) => res.map_err(CoreError::from),
             _ => return Err(AuthError::from(CoreError::from("Unexpected response"))),
         };
 

--- a/safe_authenticator/src/test_utils.rs
+++ b/safe_authenticator/src/test_utils.rs
@@ -479,7 +479,7 @@ where
                     Request::MData(MDataRequest::DelUserPermissions { address, .. }) => {
                         if *address.name() == ac_info.name() && address.tag() == ac_info.type_tag()
                         {
-                            Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                            Some(Response::Write(Err(SndError::InsufficientBalance)))
                         } else {
                             None
                         }

--- a/safe_authenticator/src/tests/mod.rs
+++ b/safe_authenticator/src/tests/mod.rs
@@ -73,7 +73,7 @@ mod mock_routing {
                             put_mdata_counter += 1;
 
                             if put_mdata_counter > 4 {
-                                Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                                Some(Response::Write(Err(SndError::InsufficientBalance)))
                             } else {
                                 None
                             }
@@ -132,8 +132,8 @@ mod mock_routing {
         // Register a hook prohibiting mutations and login
         let cm_hook = move |mut cm: ConnectionManager| -> ConnectionManager {
             cm.set_request_hook(move |req| {
-                if req.get_type() == RequestType::Mutation {
-                    Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                if req.get_type() == RequestType::Write {
+                    Some(Response::Write(Err(SndError::InsufficientBalance)))
                 } else {
                     // Pass-through
                     None
@@ -191,7 +191,7 @@ mod mock_routing {
                     // the `mutate_mdata_entries` operation (relating to
                     // the addition of the app to the user's config dir)
                     Request::Client(ClientRequest::InsAuthKey { .. }) => {
-                        Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                        Some(Response::Write(Err(SndError::InsufficientBalance)))
                     }
                     // Pass-through
                     _ => None,
@@ -237,7 +237,7 @@ mod mock_routing {
                         reqs_counter += 1;
 
                         if reqs_counter == 2 {
-                            Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                            Some(Response::Write(Err(SndError::InsufficientBalance)))
                         } else {
                             None
                         }
@@ -264,7 +264,7 @@ mod mock_routing {
             cm.set_request_hook(move |req| {
                 match *req {
                     Request::MData(MDataRequest::Put { .. }) => {
-                        Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                        Some(Response::Write(Err(SndError::InsufficientBalance)))
                     }
 
                     // Pass-through
@@ -289,7 +289,7 @@ mod mock_routing {
             cm.set_request_hook(move |req| {
                 match *req {
                     Request::MData(MDataRequest::MutateEntries { .. }) => {
-                        Some(Response::Mutation(Err(SndError::InsufficientBalance)))
+                        Some(Response::Write(Err(SndError::InsufficientBalance)))
                     }
 
                     // Pass-through

--- a/safe_authenticator_ffi/Cargo.toml
+++ b/safe_authenticator_ffi/Cargo.toml
@@ -21,7 +21,7 @@ log = "~0.4.1"
 rand = "~0.6"
 safe_core = { path = "../safe_core", version = "~0.41.3" }
 safe_authenticator = { path = "../safe_authenticator", version = "~0.16.3" }
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 serde = { version = "1.0.97", features = ["derive"] }
 threshold_crypto = "~0.3.2"
 tiny-keccak = "1.5.0"
@@ -38,7 +38,7 @@ safe_authenticator = { path = "../safe_authenticator", version = "~0.16.3",  fea
 ffi_utils = "~0.16.0"
 jni = "~0.12.0"
 safe_bindgen = { version = "~0.13.2", optional = true }
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 threshold_crypto = "~0.3.2"
 unwrap = "1.2.0"
 

--- a/safe_core/Cargo.toml
+++ b/safe_core/Cargo.toml
@@ -32,7 +32,7 @@ pbkdf2 = { version = "~0.3.0", default-features = false }
 quic-p2p = "~0.6.2"
 rand = "~0.6"
 regex = "1.3.1"
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 self_encryption = "~0.17.0"
 serde = { version = "1.0.97", features = ["derive", "rc"] }
 serde_json = "1.0.40"

--- a/safe_core/src/client/core_client.rs
+++ b/safe_core/src/client/core_client.rs
@@ -128,7 +128,7 @@ impl CoreClient {
             .await?;
 
             match response {
-                Response::Mutation(res) => res?,
+                Response::Write(res) => res?,
                 _ => return Err(CoreError::from("Unexpected response")),
             };
 

--- a/safe_core/src/client/mock/connection_manager.rs
+++ b/safe_core/src/client/mock/connection_manager.rs
@@ -88,7 +88,7 @@ impl ConnectionManager {
             let writing = match msg {
                 Message::Request { request, .. } => {
                     let req_type = request.get_type();
-                    req_type == RequestType::Mutation || req_type == RequestType::Transaction
+                    req_type == RequestType::Write || req_type == RequestType::Transfer
                 }
                 _ => false,
             };

--- a/safe_core/src/client/mock/tests.rs
+++ b/safe_core/src/client/mock/tests.rs
@@ -61,7 +61,7 @@ async fn process_request(
     sender: &SafeKey,
     request: Request,
 ) -> Response {
-    let sign = request.get_type() != RequestType::PublicGet;
+    let sign = request.get_type() != RequestType::PublicRead;
     let message_id = MessageId::new();
     let signature = if sign {
         Some(sender.sign(&unwrap!(serialize(&(&request, message_id)))))
@@ -487,8 +487,8 @@ async fn mutable_data_reclaim() {
     )
     .await;
     match response {
-        Response::Mutation(Err(Error::InvalidEntryActions(_))) => (),
-        Response::Mutation(Ok(())) => panic!("Unexpected success"),
+        Response::Write(Err(Error::InvalidEntryActions(_))) => (),
+        Response::Write(Ok(())) => panic!("Unexpected success"),
         res => panic!("Unexpected response: {:?}", res),
     }
 
@@ -570,8 +570,8 @@ async fn mutable_data_entry_versioning() {
     )
     .await;
     match response {
-        Response::Mutation(Err(Error::InvalidEntryActions(_))) => (),
-        Response::Mutation(Ok(())) => panic!("Unexpected success"),
+        Response::Write(Err(Error::InvalidEntryActions(_))) => (),
+        Response::Write(Ok(())) => panic!("Unexpected success"),
         res => panic!("Unexpected response: {:?}", res),
     }
 
@@ -588,8 +588,8 @@ async fn mutable_data_entry_versioning() {
     )
     .await;
     match response {
-        Response::Mutation(Err(Error::InvalidEntryActions(_))) => (),
-        Response::Mutation(Ok(())) => panic!("Unexpected success"),
+        Response::Write(Err(Error::InvalidEntryActions(_))) => (),
+        Response::Write(Ok(())) => panic!("Unexpected success"),
         res => panic!("Unexpected response: {:?}", res),
     }
 
@@ -628,8 +628,8 @@ async fn mutable_data_entry_versioning() {
     )
     .await;
     match response {
-        Response::Mutation(Err(Error::InvalidEntryActions(_))) => (),
-        Response::Mutation(Ok(())) => panic!("Unexpected success"),
+        Response::Write(Err(Error::InvalidEntryActions(_))) => (),
+        Response::Write(Ok(())) => panic!("Unexpected success"),
         res => panic!("Unexpected response: {:?}", res),
     }
 
@@ -1363,7 +1363,7 @@ async fn low_balance_check() {
         )
         .await;
         match response {
-            Response::Mutation(res) => assert_eq!(*unlimited, res.is_ok()), // Should succeed if unlimited is true
+            Response::Write(res) => assert_eq!(*unlimited, res.is_ok()), // Should succeed if unlimited is true
             res => panic!("Unexpected response {:?}", res),
         }
 
@@ -1460,12 +1460,12 @@ async fn request_hooks() {
         match *req {
             Request::MData(MDataRequest::Put(ref data)) if data.tag() == 10_000u64 => {
                 // Send an OK response but don't put data on the mock vault
-                Some(Response::Mutation(Ok(())))
+                Some(Response::Write(Ok(())))
             }
             Request::MData(MDataRequest::MutateEntries { address, .. })
                 if address.tag() == 12_345u64 =>
             {
-                Some(Response::Mutation(Err(custom_error.clone())))
+                Some(Response::Write(Err(custom_error.clone())))
             }
             // Pass-throug)h
             _ => None,

--- a/safe_core/src/client/mock/vault/client.rs
+++ b/safe_core/src/client/mock/vault/client.rs
@@ -44,7 +44,7 @@ impl Vault {
                 } else {
                     self.ins_auth_key(&requester.name(), *key, *permissions, *version)
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
             ClientRequest::DelAuthKey { key, version } => {
                 let result = if owner_pk != requester_pk {
@@ -52,7 +52,7 @@ impl Vault {
                 } else {
                     self.del_auth_key(&requester.name(), *key, *version)
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
         }
     }

--- a/safe_core/src/client/mock/vault/idata.rs
+++ b/safe_core/src/client/mock/vault/idata.rs
@@ -53,11 +53,11 @@ impl Vault {
                         requester,
                     )
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
             IDataRequest::DeleteUnpub(address) => {
                 let result = self.delete_idata(*address, requester_pk);
-                Response::Mutation(result)
+                Response::Write(result)
             }
         }
     }

--- a/safe_core/src/client/mock/vault/login_packet.rs
+++ b/safe_core/src/client/mock/vault/login_packet.rs
@@ -86,9 +86,9 @@ impl Vault {
                 if let Err(e) =
                     self.authorise_operations(&[Operation::Mutation], source, requester_pk)
                 {
-                    Response::Mutation(Err(e))
+                    Response::Write(Err(e))
                 } else if self.get_login_packet(account_data.destination()).is_some() {
-                    Response::Mutation(Err(SndError::LoginPacketExists))
+                    Response::Write(Err(SndError::LoginPacketExists))
                 } else {
                     let result = self
                         .get_balance(&source)
@@ -100,7 +100,7 @@ impl Vault {
                             Ok(())
                         })
                         .map(|_| self.insert_login_packet(account_data.clone()));
-                    Response::Mutation(result)
+                    Response::Write(result)
                 }
             }
             LoginPacketRequest::Get(location) => {
@@ -133,7 +133,7 @@ impl Vault {
                         None => Err(SndError::NoSuchLoginPacket),
                     }
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
         }
     }

--- a/safe_core/src/client/mock/vault/mdata.rs
+++ b/safe_core/src/client/mock/vault/mdata.rs
@@ -46,7 +46,7 @@ impl Vault {
                         requester,
                     )
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
             MDataRequest::GetValue { address, ref key } => {
                 let data = self.get_mdata(*address, requester_pk, &request);
@@ -153,7 +153,7 @@ impl Vault {
                             Err(SndError::AccessDenied)
                         }
                     });
-                Response::Mutation(result)
+                Response::Write(result)
             }
             MDataRequest::SetUserPermissions {
                 address,
@@ -178,7 +178,7 @@ impl Vault {
 
                             Ok(())
                         });
-                Response::Mutation(result)
+                Response::Write(result)
             }
             MDataRequest::DelUserPermissions {
                 address,
@@ -201,7 +201,7 @@ impl Vault {
 
                             Ok(())
                         });
-                Response::Mutation(result)
+                Response::Write(result)
             }
             MDataRequest::ListUserPermissions { address, ref user } => {
                 let user = *user;
@@ -247,7 +247,7 @@ impl Vault {
 
                             Ok(())
                         });
-                Response::Mutation(result)
+                Response::Write(result)
             }
         }
     }

--- a/safe_core/src/client/mock/vault/mod.rs
+++ b/safe_core/src/client/mock/vault/mod.rs
@@ -356,7 +356,7 @@ impl Vault {
             let request_type = request.get_type();
 
             match request_type {
-                RequestType::PrivateGet | RequestType::Mutation | RequestType::Transaction => {
+                RequestType::PrivateRead | RequestType::Write | RequestType::Transfer => {
                     // For apps, check if its public key is listed as an auth key.
                     if is_app {
                         let auth_keys = self
@@ -375,7 +375,7 @@ impl Vault {
                         None => return Err(SndError::InvalidSignature),
                     }
                 }
-                RequestType::PublicGet => (),
+                RequestType::PublicRead => (),
             }
 
             Ok((requester_pk, owner_pk))

--- a/safe_core/src/client/mock/vault/sdata.rs
+++ b/safe_core/src/client/mock/vault/sdata.rs
@@ -40,7 +40,7 @@ impl Vault {
                     }
                     None => Err(SndError::NoSuchEntry),
                 };
-                Response::Mutation(result)
+                Response::Write(result)
             }
             SDataRequest::Get(address) => {
                 let result = self.get_sdata(*address, requester_pk, &request);
@@ -58,7 +58,7 @@ impl Vault {
                         }
                     },
                 );
-                Response::Mutation(result)
+                Response::Write(result)
             }
             SDataRequest::GetRange { address, range } => {
                 let result =
@@ -103,7 +103,7 @@ impl Vault {
                     .and_then(move |data| data.user_permissions(*user, data.permissions_index()));
                 Response::GetSDataUserPermissions(result)
             }
-            SDataRequest::Mutate(op) => {
+            SDataRequest::Edit(op) => {
                 let id = DataId::Sequence(op.address);
                 let result = self.get_sdata(op.address, requester_pk, &request).and_then(
                     move |mut sdata| {
@@ -113,9 +113,9 @@ impl Vault {
                         Ok(())
                     },
                 );
-                Response::Mutation(result)
+                Response::Write(result)
             }
-            SDataRequest::MutatePubPermissions(op) => {
+            SDataRequest::SetPubPermissions(op) => {
                 let id = DataId::Sequence(op.address);
                 let result = self.get_sdata(op.address, requester_pk, &request).and_then(
                     move |mut sdata| {
@@ -125,9 +125,9 @@ impl Vault {
                         Ok(())
                     },
                 );
-                Response::Mutation(result)
+                Response::Write(result)
             }
-            SDataRequest::MutatePrivPermissions(op) => {
+            SDataRequest::SetPrivPermissions(op) => {
                 let id = DataId::Sequence(op.address);
                 let result = self.get_sdata(op.address, requester_pk, &request).and_then(
                     move |mut sdata| {
@@ -137,9 +137,9 @@ impl Vault {
                         Ok(())
                     },
                 );
-                Response::Mutation(result)
+                Response::Write(result)
             }
-            SDataRequest::MutateOwner(op) => {
+            SDataRequest::SetOwner(op) => {
                 let id = DataId::Sequence(op.address);
                 let result = self.get_sdata(op.address, requester_pk, &request).and_then(
                     move |mut sdata| {
@@ -149,7 +149,7 @@ impl Vault {
                         Ok(())
                     },
                 );
-                Response::Mutation(result)
+                Response::Write(result)
             }
             SDataRequest::GetOwner(address) => {
                 let result =
@@ -190,11 +190,11 @@ fn check_perms_sdata(sdata: &SData, request: &SDataRequest, requester: PublicKey
             SData::Public(_) => Ok(()),
             SData::Private(_) => sdata.check_permission(SDataAction::Read, requester),
         },
-        SDataRequest::Mutate { .. } => sdata.check_permission(SDataAction::Append, requester),
-        SDataRequest::MutatePubPermissions(_) | SDataRequest::MutatePrivPermissions(_) => {
+        SDataRequest::Edit { .. } => sdata.check_permission(SDataAction::Append, requester),
+        SDataRequest::SetPubPermissions(_) | SDataRequest::SetPrivPermissions(_) => {
             sdata.check_permission(SDataAction::ManagePermissions, requester)
         }
-        SDataRequest::MutateOwner(_) => sdata.check_is_last_owner(requester),
+        SDataRequest::SetOwner(_) => sdata.check_is_last_owner(requester),
         SDataRequest::Delete(_) => match sdata {
             SData::Public(_) => Err(SndError::InvalidOperation),
             SData::Private(_) => sdata.check_is_last_owner(requester),

--- a/safe_core/src/connection_manager/connection_group.rs
+++ b/safe_core/src/connection_manager/connection_group.rs
@@ -320,7 +320,7 @@ impl Connected {
         trace!("Sending message {:?}", msg_id);
 
         let (sender_future, response_future) = oneshot::channel();
-        let expected_responses = if is_get_request(&msg) {
+        let expected_responses = if is_read(&msg) {
             self.elders.len()
         } else {
             self.elders.len() / 2 + 1
@@ -375,11 +375,11 @@ impl Connected {
     }
 }
 
-// Returns true when a message holds a GET request.
-fn is_get_request(msg: &Message) -> bool {
+// Returns true when a message is a request to read.
+fn is_read(msg: &Message) -> bool {
     if let Message::Request { request, .. } = msg {
         match request.get_type() {
-            RequestType::PublicGet | RequestType::PrivateGet => true,
+            RequestType::PublicRead | RequestType::PrivateRead => true,
             _ => false,
         }
     } else {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,7 +15,7 @@ futures = "~0.3.5"
 safe_app = { path = "../safe_app", version = "~0.16.3", features = ["testing"] }
 safe_authenticator = { path = "../safe_authenticator", version = "~0.16.3", features = ["testing"] }
 safe_core = { path = "../safe_core", version = "~0.41.3", features = ["testing"] }
-safe-nd = "~0.10.0"
+safe-nd = { git = "https://github.com/oetyng/safe-nd.git", branch = "introduce_read_write" }
 serde = "1.0.24"
 serde_derive = "1.0.24"
 serde_json = "1.0.2"


### PR DESCRIPTION
- Replaces `Get`/`Mutation` with `Read`/`Write`,
 as a first step of `Request` structure refactor.
 - `MutableData` not included as it is still due for CRDT refactor.

Draft until corresponding `safe-nd` PR is merged (for force pushing update to `Cargo.toml`).